### PR TITLE
Update vagrant box to bento/22.04 (Jammy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following `mandatory` packages must be installed through Chocolatey:
 ## Vagrant Box
 
 ### Base Box
-Based on Ubuntu `focal/20.04` box from: [HashiCorp's Vagrant Cloud](https://app.vagrantup.com/ubuntu/boxes/focal64)
+Based on Ubuntu `jammy/22.04` box from: [HashiCorp's Vagrant Cloud](https://app.vagrantup.com/bento/boxes/ubuntu-22.04)
 
 ### Hashicorp
 - vagrant
@@ -110,6 +110,7 @@ Based on Ubuntu `focal/20.04` box from: [HashiCorp's Vagrant Cloud](https://app.
 
 ### Linters
 - hadolint
+- golint
 
 ### User Workspace Settings
 - .vimrc
@@ -118,9 +119,6 @@ Based on Ubuntu `focal/20.04` box from: [HashiCorp's Vagrant Cloud](https://app.
 - .bash_aliases
 - ipython_config.py
 - .lsyncd.config.lua
-
-### Browsers
-- midori
 
 ### Others
 - lynx

--- a/docs/vagrant/system.md
+++ b/docs/vagrant/system.md
@@ -18,13 +18,14 @@ Most popular are the [Bento boxes](https://vagrantcloud.com/bento). The Bento bo
     - [Ubuntu/Xenial64](https://app.vagrantup.com/generic/boxes/ubuntu1604)
     - [Ubuntu/Bionic64](https://app.vagrantup.com/generic/boxes/ubuntu1804)
     - [Ubuntu/Focal64](https://app.vagrantup.com/ubuntu/boxes/focal64)
+    - [Ubuntu/Jammy64](https://app.vagrantup.com/ubuntu/boxes/jammy64)
 
 In order to **update the base box** you need to set to ``true`` the value of the ``update`` key.<br>
 
 ```yaml
 :host:
     :update: false
-    :box: 'bento/ubuntu-18.04'
+    :box: 'bento/ubuntu-22.04'
 ```
 
 Moreover, if you want to **completely change the base box** you need to:

--- a/provisioners/ansible/roles/common/system/defaults/main.yml
+++ b/provisioners/ansible/roles/common/system/defaults/main.yml
@@ -34,6 +34,5 @@ system_required_packages:
   - 'bridge-utils'
   - 'xdg-utils'
   - 'jq'
-  - 'midori'
 system_inotify_filewatchers: '131072'
 ...

--- a/provisioners/ansible/roles/ruby/defaults/main.yml
+++ b/provisioners/ansible/roles/ruby/defaults/main.yml
@@ -2,6 +2,6 @@
 ruby_dependencies:
     - 'ruby-full'
 ruby_install_bundler: true
-ruby_bundler_version: '2.2.22'
+ruby_bundler_version: '2.3.23'
 ruby_install_user_gems: []
 ...

--- a/vagrant.yaml
+++ b/vagrant.yaml
@@ -30,7 +30,7 @@
 :host:
     :name: &hostname 'sandbox'
     :box_update: false
-    :box: 'bento/ubuntu-20.04'
+    :box: 'bento/ubuntu-22.04'
     :box_url: null
     :cpus: null
     :memory: null


### PR DESCRIPTION
- Update README.md
- Update project documentation, supported boxes
- Update ansible provisioners
  - Update ruby bundler to version ``2.3.23``
  - Update common/system packages, remove midori browser
- Update vagrant.yaml
  - Update default base box to: ``ubuntu`` ``bento/22.04``