### PR TITLE
Add (new env) testing support to tox.ini

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - 'checkout'
       - run:
-          name: 'Run Continuous Integration tests'
-          command: 'tox'
+          name: 'Run Continuous Integration (linting, testing, ...)'
+          command: 'tox -p'
 workflows:
   on_commit:
     jobs:

--- a/requirements.d/ansible.txt
+++ b/requirements.d/ansible.txt
@@ -1,3 +1,3 @@
-# Requirements for bootstrapping shell provisioner
+# Requirements for bootstrapping ansible through shell provisioner
 
 ansible==6.5.0

--- a/requirements.d/tests.txt
+++ b/requirements.d/tests.txt
@@ -1,0 +1,4 @@
+# Requirements for [testenv:tests] virtualenv
+
+pytest==7.1.3
+-r ansible.txt

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 project = Vagrantenv (Sandbox)
 minversion = 3.7.0
 skipsdist = true
-envlist = py3,linters
+envlist = pre-testenvs,linters,tests
 skip_missing_interpreters = true
 
 
@@ -31,18 +31,29 @@ deps = -r requirements.d/testenv.txt
 parallel_show_output = true
 commands =
     - bash -c 'find {toxinidir} -type d -name "__pycache__" | xargs rm -rf'
+    - bash -c 'find {toxinidir} -type d -name ".pytest_cache" | xargs rm -rf'
+    - bash -c 'find {toxinidir} -type d -name ".bundle" | xargs rm -rf'
     {envpython} -m pip check
 
 
 [testenv:linters]
 description = Execute all project linters
+depends = pre-testenvs
 deps = -r requirements.d/linters.txt
 commands =
     {envpython} -m pre_commit run {posargs:--all-files --verbose}
 
 
+[testenv:tests]
+description = Execute project test automation
+depends = pre-testenvs
+deps = -r requirements.d/tests.txt
+commands =
+    {envpython} -m pytest {posargs:-s -v}
+
+
 [testenv:docs]
-description = Project documentation
+description = Generate project documentation
 deps = -r requirements.d/docs.txt
 commands =
     {envpython} -m mkdocs serve {posargs}


### PR DESCRIPTION
- Update tox.md documentation file
- Add requirements.d/tests.txt
  - Add pytest==7.3.1 pinned dependency
- Update .circleci/config.yml
  - Update CI command for parallel test execution
- Update tox.ini
  - Add virtualenv [testenv:tests]
  - Add option depends for [testenv:linters] and [testenv:tests]