### PR TITLE
Update vagrant.yaml networking

### DIFF
--- a/vagrant.yaml
+++ b/vagrant.yaml
@@ -118,7 +118,7 @@
               :disabled: false
               :options:
                   - :type: 'static'
-                    :ip: '172.16.0.2'
+                    :ip: '192.168.56.2'
                     :netmask: '255.255.255.252'
                     :nic_type: 'virtio'
                     :goodhosts: 'no_skip'


### PR DESCRIPTION
- Fix vagrant up (instantiation) error when ip address range for host-network only adapter is not in 192.168.56.0/21 range