### PR TITLE
Update vagrant to version 2.3.4, plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,18 @@ RUN curl -OLs https://github.com/hadolint/hadolint/releases/download/v"${HADOLIN
     mv hadolint-Linux-x86_64 /usr/local/bin/hadolint && \
     chmod a+x /usr/local/bin/hadolint
 
-ARG VAGRANT_VERSION="2.2.19"
+ARG VAGRANT_VERSION="2.3.4"
 
-RUN curl -OLs https://releases.hashicorp.com/vagrant/"${VAGRANT_VERSION}"/vagrant_"${VAGRANT_VERSION}"_x86_64.deb && \
-    dpkg -i vagrant_"${VAGRANT_VERSION}"_x86_64.deb && \
-    rm vagrant_"${VAGRANT_VERSION}"_x86_64.deb
+RUN if dpkg --compare-versions "${VAGRANT_VERSION}" ge 2.3.0; then \
+    VERSION="${VAGRANT_VERSION}-1"; \
+    ARCH=amd64; \
+    else \
+    VERSION="${VAGRANT_VERSION}"; \
+    ARCH=x86_64; \
+    fi && \
+    curl -OLs https://releases.hashicorp.com/vagrant/"${VAGRANT_VERSION}"/vagrant_"${VERSION}"_"${ARCH}".deb && \
+    dpkg -i vagrant_"${VERSION}"_"${ARCH}".deb && \
+    rm vagrant_"${VERSION}"_"${ARCH}".deb
 
 ARG BUNDLER_VERSION="2.3.23"
 

--- a/provisioners/ansible/extra_vars.yml
+++ b/provisioners/ansible/extra_vars.yml
@@ -17,5 +17,5 @@ kubeps1_version: 0.8.0
 kubeshark_version: 38.3
 tf_version: 1.3.6
 tgrunt_version: 0.40.0
-vagrant_version: 2.2.19
+vagrant_version: 2.3.4
 yq_version: 4.30.6

--- a/provisioners/ansible/roles/hashicorp/vagrant/defaults/main.yml
+++ b/provisioners/ansible/roles/hashicorp/vagrant/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-vagrant_version: '2.2.19'
+vagrant_version: '2.3.4'
 ...

--- a/provisioners/ansible/roles/hashicorp/vagrant/vars/main.yml
+++ b/provisioners/ansible/roles/hashicorp/vagrant/vars/main.yml
@@ -1,5 +1,7 @@
 ---
-vagrant_package: 'vagrant_{{ vagrant_version }}_{{ ansible_architecture }}.deb'
+vagrant_architecture: '{{ "amd64" if vagrant_version is version("2.3.0", ">=") else ansible_architecture }}'
+vagrant_updated_version: '{{ vagrant_version + "-1" if vagrant_version is version("2.3.0", ">=") else vagrant_version }}'
+vagrant_package: 'vagrant_{{ vagrant_updated_version }}_{{ vagrant_architecture }}.deb'
 vagrant_download_url: 'https://releases.hashicorp.com/vagrant/{{ vagrant_version }}/{{ vagrant_package }}'
 vagrant_download_dest: '/tmp/{{ vagrant_package }}'
 ...

--- a/tools/helpers/string.sh
+++ b/tools/helpers/string.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+version() {
+    echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
+}

--- a/tools/linux/provision.sh
+++ b/tools/linux/provision.sh
@@ -12,14 +12,16 @@ source ${CWD}/../helpers/log.sh
 source ${CWD}/../helpers/system.sh
 # shellcheck source=tools/helpers/pacapt.sh
 source ${CWD}/../helpers/pacapt.sh
+# shellcheck source=tools/helpers/string.sh
+source ${CWD}/../helpers/string.sh
 
-VAGRANT_VERSION='2.2.19'
+
+VAGRANT_VERSION='2.3.4'
 VAGRANT_VIRTUALBOX_VERSION='virtualbox'
 VAGRANT_TMP_DIR='/tmp/downloads'
 VAGRANT_TMP_DEB="${VAGRANT_TMP_DIR}/vagrant_${VAGRANT_VERSION}.deb"
 VAGRANT_TMP_RPM="${VAGRANT_TMP_DIR}/vagrant_${VAGRANT_VERSION}.rpm"
-VAGRANT_URL_DEB="https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_$(uname -m).deb"
-VAGRANT_URL_RPM="https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_$(uname -m).rpm"
+VAGRANT_BASE_URL="https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}"
 
 
 install_virtualbox() {
@@ -31,13 +33,44 @@ install_virtualbox() {
   error "Fail to install ${VAGRANT_VIRTUALBOX_VERSION}"
 }
 
+_is_vagrant_updated_version() {
+  if [[ $(version "${VAGRANT_VERSION}") -ge $(version "2.3.0") ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+_vagrant_version() {
+  if _is_vagrant_updated_version; then
+    echo "${VAGRANT_VERSION}-1"
+  else
+    echo "${VAGRANT_VERSION}"
+  fi
+}
+
+_vagrant_debian_arch() {
+  local arch
+  arch=$(uname -m)
+  if _is_vagrant_updated_version; then
+    if [[ $arch == "x86_64" ]]; then
+      arch="amd64"
+    fi
+  fi
+  echo "${arch}"
+}
+
 _install_vagrant() {
-  local url package
+  local url package version arch
   if pacman -P |grep -q 'dpkg'; then
-    url=${VAGRANT_URL_DEB}
+    version=$(_vagrant_version)
+    arch=$(_vagrant_debian_arch)
+    url="${VAGRANT_BASE_URL}/vagrant_${version}_${arch}.deb"
     package=${VAGRANT_TMP_DEB}
   else
-    url=${VAGRANT_URL_RPM}
+    version=$(_vagrant_version)
+    arch=$(uname -m)
+    url="${VAGRANT_BASE_URL}/vagrant_${version}_${arch}.rpm"
     package=${VAGRANT_TMP_RPM}
   fi
   mkdir -p "${VAGRANT_TMP_DIR}" && \

--- a/vagrant.yaml
+++ b/vagrant.yaml
@@ -10,13 +10,13 @@
 # Required Vagrant plugins
 :plugins:
     - :name: "vagrant-vbguest"
-      :version: "0.30.0"
+      :version: "0.31.0"
     - :name: "sahara"
       :version: "0.0.17"
     - :name: "vagrant-proxyconf"
       :version: "2.0.10"
     - :name: "vagrant-goodhosts"
-      :version: "1.1.4"
+      :version: "1.1.5"
     - :name: "vagrant-netinfo"
       :version: "0.0.4"
 


### PR DESCRIPTION
- Update vagrant version to 2.3.4 in Dockerfile
- Update vagrant version to 2.3.4 in linux/provision.sh
- Update vagrant version to 2.3.4 in ansible role
- Update vagrant plugins in vagrant.yaml
  - vagrant-vbguest == 0.31.0
  - vagrant-goodhosts == 1.1.5