### PR TITLE
Add ansible role to provision helm-dashboard tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Based on Ubuntu `jammy/22.04` box from: [HashiCorp's Vagrant Cloud](https://app.
 - docker-compose
 - kubectl
 - helm
+- helm-dashboard
 - kind
 - k9s
 - kubectx

--- a/docs/vagrant/provisioners.md
+++ b/docs/vagrant/provisioners.md
@@ -216,6 +216,7 @@ Supported options are:
             - [kind](https://kind.sigs.k8s.io/) - Running local Kubernetes clusters inside Docker container "nodes".
             - [kubectl](https://kubernetes.io/docs/tasks/tools/) - The Kubernetes command line tool.
             - [helm](https://helm.sh/) - The package manager for Kubernetes.
+            - [helm-dashboard](https://github.com/komodorio/helm-dashboard) - UI-driven way to view the installed Helm charts.
             - [hadolint](https://github.com/hadolint/hadolint) - Haskell Dockerfile linter.
             - [groovy](https://groovy-lang.org/) - The optional-typed Apache Groovy language.
             - [k9s](https://github.com/derailed/k9s) - Kubernetes CLI to manager your clusters.

--- a/provisioners/ansible/extra_vars.yml
+++ b/provisioners/ansible/extra_vars.yml
@@ -6,6 +6,7 @@ go_checksum: c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8
 go_version: 1.19.4
 hadolint_version: 2.12.0
 helm_version: 3.10.3
+helm_dashboard_version: 1.1.1
 hvault_version: 1.10.0
 k9s_version: 0.26.7
 kind_version: 0.17.0

--- a/provisioners/ansible/playbook.yml
+++ b/provisioners/ansible/playbook.yml
@@ -17,6 +17,7 @@
     - { role: 'kubernetes/kind', tags: 'kind' }
     - { role: 'kubernetes/kubectl', tags: 'kubectl' }
     - { role: 'kubernetes/helm', tags: 'helm' }
+    - { role: 'kubernetes/helm_dashboard', tags: 'helm_dash' }
     - { role: 'kubernetes/k9s', tags: 'k9s' }
     - { role: 'kubernetes/kubefwd', tags: 'kubefwd' }
     - { role: 'kubernetes/kubectx', tags: 'kubectx' }

--- a/provisioners/ansible/roles/kubernetes/helm_dashboard/defaults/main.yml
+++ b/provisioners/ansible/roles/kubernetes/helm_dashboard/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+helm_dashboard_version: '1.1.1'
+helm_dashboard_install_dir: '/usr/local/bin'
+...

--- a/provisioners/ansible/roles/kubernetes/helm_dashboard/handlers/main.yml
+++ b/provisioners/ansible/roles/kubernetes/helm_dashboard/handlers/main.yml
@@ -1,0 +1,16 @@
+---
+- name: 'Check installed {{ helm_dashboard_binary_name }} version'
+  shell: '{{ helm_dashboard_install_dir }}/{{ helm_dashboard_binary_name }} --version'
+  args:
+    executable: '/bin/bash'
+  changed_when: false
+  register: 'helm_dashboard_installed_version'
+
+- name: 'Verify installed {{ helm_dashboard_binary_name }} version'
+  assert:
+    that:
+      - 'helm_dashboard_installed_version.stdout is version(helm_dashboard_version, "=")'
+    fail_msg: "{{ helm_dashboard_binary_name }} installation failed, \
+               v{{ helm_dashboard_version }} != {{ helm_dashboard_installed_version.stdout }}"
+    success_msg: 'Installed {{ helm_dashboard_binary_name }} version is: v{{ helm_dashboard_version }}'
+...

--- a/provisioners/ansible/roles/kubernetes/helm_dashboard/tasks/main.yml
+++ b/provisioners/ansible/roles/kubernetes/helm_dashboard/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+- name: 'Check if is already installed'
+  stat:
+    path: '{{ helm_dashboard_install_dir }}/{{ helm_dashboard_binary_name }}'
+  register: 'helm_dashboard_check_existing'
+
+- name: 'Check existing version'
+  shell: "{{ helm_dashboard_install_dir }}/{{ helm_dashboard_binary_name }} --version"
+  args:
+    executable: '/bin/bash'
+  failed_when: false
+  changed_when: false
+  register: 'helm_dashboard_installed_version'
+  when: 'helm_dashboard_check_existing.stat.exists'
+
+- name: 'Retrieve binary checksum'
+  set_fact:
+    helm_dashboard_checksum_data: '{{ lookup("url", helm_dashboard_checksum_url) }}'
+  when: >
+    not helm_dashboard_check_existing.stat.exists
+    or helm_dashboard_installed_version.stdout is not version(helm_dashboard_version, "=")
+
+- name: 'Convert checksum to dictionary'
+  set_fact:
+    helm_dashboard_checksum_dict: '{{ helm_dashboard_checksum_data | content_to_dict(",") }}'
+  when: >
+    not helm_dashboard_check_existing.stat.exists
+    or helm_dashboard_installed_version.stdout is not version(helm_dashboard_version, "=")
+
+- name: 'Set binary checksum value'
+  set_fact:
+    helm_dashboard_checksum: '{{ helm_dashboard_checksum_dict | get_dict_key(helm_dashboard_tarball) }}'
+  when: >
+    not helm_dashboard_check_existing.stat.exists
+    or helm_dashboard_installed_version.stdout is not version(helm_dashboard_version, "=")
+
+- name: 'Ensure install directory exists'
+  file:
+    path: '{{ helm_dashboard_install_dir }}'
+    state: 'directory'
+    mode: 0755
+    owner: 'root'
+    group: 'root'
+  become: 'yes'
+
+- name: 'Remove any installed binary'
+  file:
+    path: '{{ helm_dashboard_install_dir }}/{{ helm_dashboard_binary_name }}'
+    state: 'absent'
+  become: 'yes'
+  when:
+    - 'helm_dashboard_check_existing.stat.exists'
+    - 'helm_dashboard_installed_version.stdout is not version(helm_dashboard_version, "=")'
+
+- name: 'Download tarball'
+  get_url:
+    url: '{{ helm_dashboard_tarball_url }}'
+    dest: '/tmp/{{ helm_dashboard_tarball }}'
+    checksum: 'sha256:{{ helm_dashboard_checksum }}'
+  become: 'yes'
+  when: >
+    not helm_dashboard_check_existing.stat.exists
+    or helm_dashboard_installed_version.stdout is not version(helm_dashboard_version, "=")
+
+- name: 'Extract tarball'
+  unarchive:
+    src: '/tmp/{{ helm_dashboard_tarball }}'
+    dest: '{{ helm_dashboard_install_dir }}'
+    remote_src: 'yes'
+    mode: 0755
+    owner: 'root'
+    group: 'root'
+  become: 'yes'
+  notify:
+    - 'Check installed {{ helm_dashboard_binary_name }} version'
+    - 'Verify installed {{ helm_dashboard_binary_name }} version'
+  when: >
+    not helm_dashboard_check_existing.stat.exists
+    or helm_dashboard_installed_version.stdout is not version(helm_dashboard_version, "=")
+...

--- a/provisioners/ansible/roles/kubernetes/helm_dashboard/vars/main.yml
+++ b/provisioners/ansible/roles/kubernetes/helm_dashboard/vars/main.yml
@@ -1,0 +1,13 @@
+---
+helm_dashboard_arch: '{{ ansible_architecture }}'
+helm_dashboard_os: '{{ ansible_system }}'
+helm_dashboard_base_binary_url: 'https://github.com/komodorio/helm-dashboard/releases/download/v{{ helm_dashboard_version }}'
+helm_dashboard_binary_name: 'helm-dashboard'
+helm_dashboard_tarball:
+    "{{ helm_dashboard_binary_name }}_{{ helm_dashboard_version }}_\
+    {{ helm_dashboard_os }}_{{ helm_dashboard_arch }}.tar.gz"
+helm_dashboard_tarball_url: '{{ helm_dashboard_base_binary_url }}/{{ helm_dashboard_tarball }}'
+helm_dashboard_checksum_url:
+    "{{ helm_dashboard_base_binary_url }}/{{ helm_dashboard_binary_name }}_\
+     {{ helm_dashboard_version }}_checksums.txt"
+...

--- a/vagrant.yaml
+++ b/vagrant.yaml
@@ -33,7 +33,7 @@
     :box_url: null
     :cpus: null
     :memory: null
-    :boot_timeout: 60
+    :boot_timeout: 120
     :gui: false
     :disks:
         - :type: "disk"
@@ -197,6 +197,7 @@
                     - "kubectx"
                     - "kubefwd"
                     - "helm"
+                    - "helm_dash"
                     - "kind"
                     - "k9s"
                     - "kubecolor"


### PR DESCRIPTION
- Update ansible roles
  - Add kubernetes role, helm-dashboard to visualize installed helm charts
- Update vagrant.yaml
  - Increase timeout to 2mins
- Update README.md
- Update documentation for the new role
- Update ansible extra_vars.yaml
  - Add helm-dashboard version to 1.1.1
- Update ansible playbook.yaml
  - Add helm-dashboard role and tag name