### PR TITLE
Hotfix rubuy 3.1 due to vagrant 2.3.6 update

### DIFF
--- a/lib/vagrant-host.rb
+++ b/lib/vagrant-host.rb
@@ -30,7 +30,7 @@ module Host
                     options[:path] = Utils.expand_host_path(path)
                 end
             end
-            vm.provision shell[:name], shell[:options]
+            vm.provision shell[:name], **shell[:options]
         end
     end
 
@@ -68,7 +68,7 @@ module Host
             next unless data.key?(:options)
 
             options = data[:options]
-            options.each { |opts| vm.network data[:type], opts }
+            options.each { |opts| vm.network data[:type], **opts }
         end
     end
 
@@ -88,7 +88,7 @@ module Host
                 opts[path] = filepath
             end
         end
-        vm.provision name, opts
+        vm.provision name, **opts
     end
 
     def disks(vm, host)
@@ -103,7 +103,7 @@ module Host
             type = disk[:type].to_s.to_sym
             opts = disk.fetch(:options, {})
             opts[:name] ||= "storage-#{index}"
-            vm.disk type, opts
+            vm.disk type, **opts
         end
     end
 

--- a/lib/vagrant-utils.rb
+++ b/lib/vagrant-utils.rb
@@ -25,7 +25,12 @@ module Utils
 
     def load_config(config_file)
         raise_msg "Configuration file #{config_file} not found!" unless File.exist?(config_file)
-        return YAML.load_file(config_file)
+        begin
+            config = YAML.load_file(config_file, aliases: true)
+        rescue ArgumentError
+            config = YAML.load_file(config_file)
+        end
+        return config
     end
 
     def cpus


### PR DESCRIPTION
- YAML.load_file and YAML.safe_load for Ruby 3.1
  - https://github.com/ruby/psych/issues/533
- Separation of positional and keyword arguments in ruby3.0