### PR TITLE
Update vagrant to version 2.3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN apt-get update && \
     python3-dev && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-ARG HADOLINT_VERSION="2.10.0"
+ARG HADOLINT_VERSION="2.12.0"
 
 RUN curl -OLs https://github.com/hadolint/hadolint/releases/download/v"${HADOLINT_VERSION}"/hadolint-Linux-x86_64 && \
     mv hadolint-Linux-x86_64 /usr/local/bin/hadolint && \
     chmod a+x /usr/local/bin/hadolint
 
-ARG VAGRANT_VERSION="2.3.6"
+ARG VAGRANT_VERSION="2.3.7"
 
 RUN if dpkg --compare-versions "${VAGRANT_VERSION}" ge 2.3.0; then \
     VERSION="${VAGRANT_VERSION}-1"; \
@@ -35,7 +35,7 @@ RUN if dpkg --compare-versions "${VAGRANT_VERSION}" ge 2.3.0; then \
     dpkg -i vagrant_"${VERSION}"_"${ARCH}".deb && \
     rm vagrant_"${VERSION}"_"${ARCH}".deb
 
-ARG BUNDLER_VERSION="2.3.23"
+ARG BUNDLER_VERSION="2.4.18"
 
 RUN gem install bundler --version "${BUNDLER_VERSION}"
 
@@ -54,8 +54,8 @@ USER "${USERNAME}"
 ENV LANG="C.UTF-8" \
     PATH="/home/${USERNAME}/.local/bin:${PATH}"
 
-ARG PIP_VERSION="22.3" \
-    TOX_VERSION="4.2.6"
+ARG PIP_VERSION="23.2.1" \
+    TOX_VERSION="4.6.4"
 
 RUN python3 -m pip install --user --no-compile --no-cache-dir --upgrade pip=="${PIP_VERSION}" && \
     python3 -m pip install --user --no-compile --no-cache-dir tox=="${TOX_VERSION}"

--- a/provisioners/ansible/extra_vars.yml
+++ b/provisioners/ansible/extra_vars.yml
@@ -1,24 +1,24 @@
 ---
-fzf_version: 0.35.1
+fzf_version: 0.42.0
 gitconfig_user_email: tgeorgomanolis@gmail.com
 gitconfig_user_name: Theodoros Georgomanolis
 go_checksum: c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8
 go_version: 1.19.4
 hadolint_version: 2.12.0
-helm_version: 3.10.3
-helm_dashboard_version: 1.1.1
+helm_version: 3.12.2
+helm_dashboard_version: 1.3.3
 hvault_version: 1.10.0
-k9s_version: 0.26.7
-kind_version: 0.17.0
+k9s_version: 0.27.4
+kind_version: 0.20.0
 kubecolor_version: 0.0.25
 kubectl_version: 1.25.0
 kubectx_version: 0.9.4
 kubefwd_version: 1.22.4
 kubeps1_version: 0.8.0
-kubeshark_version: 38.3
+kubeshark_version: 41.6
 kubetail_version: 1.6.17
 tf_version: 1.3.6
 tgrunt_version: 0.40.0
-vagrant_version: 2.3.6
+vagrant_version: 2.3.7
 yq_version: 4.30.6
 allure_version: 2.22.4

--- a/tools/linux/provision.sh
+++ b/tools/linux/provision.sh
@@ -16,7 +16,7 @@ source ${CWD}/../helpers/pacapt.sh
 source ${CWD}/../helpers/string.sh
 
 
-VAGRANT_VERSION='2.3.6'
+VAGRANT_VERSION='2.3.7'
 VAGRANT_VIRTUALBOX_VERSION='virtualbox'
 VAGRANT_TMP_DIR='/tmp/downloads'
 VAGRANT_TMP_DEB="${VAGRANT_TMP_DIR}/vagrant_${VAGRANT_VERSION}.deb"

--- a/tools/windows/chocolatey.config
+++ b/tools/windows/chocolatey.config
@@ -6,6 +6,6 @@ https://github.com/chocolatey/choco/wiki/CommandsInstall#packagesconfig
 <packages>
   <package id="virtualbox" version="6.1.16" packageParameters="/NoDesktopShortcut" allowMultipleVersions="false"/>
   <package id="python3" version="3.11.0"/>
-  <package id="vagrant" version="2.3.6"/>
+  <package id="vagrant" version="2.3.7"/>
   <package id="vscode" version="1.72.2"/>
 </packages>

--- a/vagrant.yaml
+++ b/vagrant.yaml
@@ -16,7 +16,7 @@
     - :name: "vagrant-proxyconf"
       :version: "2.0.10"
     - :name: "vagrant-goodhosts"
-      :version: "1.1.5"
+      :version: "1.1.6"
     - :name: "vagrant-netinfo"
       :version: "0.0.4"
 


### PR DESCRIPTION
- Update ansible roles:
  - KIND to v0.20.0
  - Kubeshark to v0.41.6
  - Helm to v3.12.2
  - K9s v0.27.4
  - Helm Dashboard v1.3.3
  - FZF to v0.42.0